### PR TITLE
Remove chinese characters from the browser tab name.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,8 +4,8 @@ keywords: blog,css,html,php
 author: "Iva Laginja"
 
 #title hide and show
-hide: (つェ⊂)我藏好啦
-show: ´∇｀ 呀被发现啦~ 
+#hide:
+#show:
 
 baseurl: "" # change this to the subpath of your site, e.g. /blog. Leave it empty if you don't need it.
 url: "highconaotools.github.io" # change this to the base hostname & protocol for your site


### PR DESCRIPTION
Adresses #3 .

To do so, i commented the 2 variables 'hide' and 'show' in the '_config.yml' file of the website. The name of the browser tab is now the name of the page that is open (it changes automatically). May be we want it to stick to 'CAOTIC' ?